### PR TITLE
Ignore case when comparing directives

### DIFF
--- a/cl-format.el
+++ b/cl-format.el
@@ -115,11 +115,7 @@ CL format parlance\)."
 
 (defun cl-format-get-directive (char)
   "Return the clx directive struct corresponding to CHAR."
-  (cdr (assq char cl-format-directives)))
-      ;; (if (eq char (downcase char))
-      ;;     (cdr (assq (upcase char) cl-format-directives))
-      ;;   (cdr (assq (downcase char) cl-format-directives)))
-
+  (cdr (cl-assoc char cl-format-directives :test 'char-equal)))
 
 (defun cl-format-parse (fmt &optional start contained-end)
   "Parse format string FMT, starting at START until CONTAINED-END char.


### PR DESCRIPTION
Hi,
  Thanks for writing cl-format! The following patch allows the user to specify directives using either upper or lower case, as it is the case in CL