### PR TITLE
Cleaner build: do not use deprecated symbols

### DIFF
--- a/cl-format-builtins.el
+++ b/cl-format-builtins.el
@@ -91,7 +91,7 @@ event."
                 ;;(append "()[]\\;'`\"#., \n\t\l\r\e" nil)
                 '(40 41 91 93 92 59 39 96 34 35 46 44 32 10 9 108 13 27))
       (push ?\\ repr))
-    (push (case char
+    (push (cl-case char
             (?\s ?s)
             (?\n ?n)
             (?\t ?t)
@@ -283,7 +283,7 @@ instead of decimal."
                           (max (- width (length str))
                                (- width (length abbrev))))))
 
-    (when (and width print-plus-sign) (decf rest-width))
+    (when (and width print-plus-sign) (cl-decf rest-width))
     (if (and width
              overflowchar
              (< rest-width 0))
@@ -571,7 +571,7 @@ change_e"
           (let ((n (clisp-float-scale-exponent arg)))
             (if (null digits)
                 (setq digits
-                      (multiple-value-bind (digits digitslength)
+                      (cl-multiple-value-bind (digits digitslength)
                           (clisp-format-float-to-string
                            (abs arg) nil nil nil nil)
                         (max (1- digitslength) 1 (min n 7)))))
@@ -654,17 +654,17 @@ change_e"
     (if (floatp arg)
         (if (not (cl-format-float-regular-p arg))
             (cl-format-float-nan/inf arg w atsign nil padchar)
-          (multiple-value-bind (num numlength
+          (cl-multiple-value-bind (num numlength
                                        leadingpoint trailingpoint leadings)
               (clisp-format-float-to-string arg nil digits 0 nil)
             (let* ((lefts (max leadings n))
-                   (totalwidth (+ (if (or atsign (minusp arg)) 1 0)
+                   (totalwidth (+ (if (or atsign (cl-minusp arg)) 1 0)
                                   lefts 1 digits))
                    (padcount (max (- w totalwidth) 0)))
               (if (not colon)
                   (clisp-format-padding
                    padcount padchar standard-output))
-              (if (minusp arg)
+              (if (cl-minusp arg)
                   (write-char ?- standard-output)
                 (if atsign (write-char ?+ standard-output)))
               (if colon
@@ -1138,7 +1138,7 @@ powerful than ~?."
           (setq container
                 (catch 'cl-format-up-and-out
                   (funcall fmt container)))))
-      (incf count)
+      (cl-incf count)
       (setq force-once nil)))
   container)
 
@@ -1393,11 +1393,11 @@ Here are some examples of the use of ~^ within a ~< construct.
 
 (defun cl-format-float-regular-p (float)
   "Check that FLOAT is a `float' and neither NaN nor INF."
-  (require 'cl)
+  (require 'cl-lib)
   (cl-float-limits)
   (and (= float float)
-       (<= float most-positive-float)
-       (>= float most-negative-float)))
+       (<= float cl-most-positive-float)
+       (>= float cl-most-negative-float)))
 
 (provide 'cl-format-builtins)
 

--- a/cl-format-def.el
+++ b/cl-format-def.el
@@ -22,10 +22,10 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 
-(defstruct (cl-format-directive
-            (:conc-name cl-format-directive/))
+(cl-defstruct (cl-format-directive
+               (:conc-name cl-format-directive/))
   char-beg
   char-end
   parameter
@@ -37,27 +37,27 @@
   colon-flag-p
   documentation)
 
-(defstruct (cl-format-base
-            (:conc-name cl-format-base/))
+(cl-defstruct (cl-format-base
+               (:conc-name cl-format-base/))
   at-flag
   colon-flag
   parameter)
 
-(defstruct (cl-format-part
-            (:conc-name cl-format-part/)
-            (:include cl-format-base))
+(cl-defstruct (cl-format-part
+               (:conc-name cl-format-part/)
+               (:include cl-format-base))
   directive
   contained
   separator
   end-separator)
 
-(defstruct (cl-format-clause-separator
-            (:conc-name cl-format-clause-separator/)
-            (:include cl-format-base)))
+(cl-defstruct (cl-format-clause-separator
+               (:conc-name cl-format-clause-separator/)
+               (:include cl-format-base)))
 
-(defstruct (cl-format-clause-end-separator
-            (:conc-name cl-format-clause-end-separator/)
-            (:include cl-format-clause-separator)))
+(cl-defstruct (cl-format-clause-end-separator
+               (:conc-name cl-format-clause-end-separator/)
+               (:include cl-format-clause-separator)))
 
 
 (defvar cl-format-directives nil
@@ -81,15 +81,15 @@ character of the directive and 'clx' is the corresponding struct.")
 
 (defun cl-define-format-directive-parse-lambda-list (list)
   "Parse lambda-list LIST for `define-cl-format-directive'."
-  (flet ((check-arg (arg)
-           (and (not (keywordp* arg))
-                (or (symbolp arg)
-                    (and (consp arg)
-                         (= (length arg) 2)
-                         (symbolp (car arg))))))
-         (keywordp* (symbol)
-           (and (symbolp symbol)
-                (eq ?& (aref (symbol-name symbol) 0)))))
+  (cl-labels ((check-arg (arg)
+                (and (not (keywordp* arg))
+                     (or (symbolp arg)
+                         (and (consp arg)
+                              (= (length arg) 2)
+                              (symbolp (car arg))))))
+              (keywordp* (symbol)
+                (and (symbolp symbol)
+                     (eq ?& (aref (symbol-name symbol) 0)))))
     (let* ((order (copy-sequence '(&args &at-flag &colon-flag &parameter
                                          &contained &separator
                                          &end-separator &stash)))
@@ -433,19 +433,19 @@ error: \"Directive ~F does not support :-flag\""
                       (or doc "FIXME: Not documented.")))
     
     (while (keywordp (car body))
-      (case (car body)
+      (cl-case (car body)
         (otherwise (error "Unrecognized keyword: %s" (car body))))
       (setq body (cddr body)))
                
-    (setq args (remove-if-not 'cdr args))
+    (setq args (cl-remove-if-not 'cdr args))
     (let* ((parm-only (cdr (assq '&parameter args)))
            (arg-only (cdr (assq '&args args)))
            (contained-only (cdr (assq '&contained args)))
-           (non-parm-arg (remove-if (lambda (kw)
-                                      (memq (car kw)
-                                            '(&parameter
-                                              &args &contained)))
-                                    args))
+           (non-parm-arg (cl-remove-if (lambda (kw)
+                                         (memq (car kw)
+                                               '(&parameter
+                                                 &args &contained)))
+                                       args))
            (ll (mapcar
                 (lambda (s)
                   (cons s (make-symbol
@@ -470,7 +470,7 @@ error: \"Directive ~F does not support :-flag\""
                (or (consp a)
                    (setq a (list a)))
                `(list ',(car a)
-                      (list 'or (list 'nth ,(incf idx)
+                      (list 'or (list 'nth ,(cl-incf idx)
                                       ',parm-symbol)
                             ',(eval (cadr a)))))
              parm-only))
@@ -554,7 +554,7 @@ error: \"Directive ~F does not support :-flag\""
   ;; later removed.  But maybe this is good enough anyway.
   (let* ((directives (assq-delete-all
                       char-beg
-                      (copy-seq cl-format-directives))))
+                      (cl-copy-seq cl-format-directives))))
     (dolist (d directives)
       (let ((other-end (cl-format-directive/char-end
                         (cdr d)))

--- a/cl-format.ert
+++ b/cl-format.ert
@@ -1,4 +1,4 @@
-;; -*- emacs-lisp -*- vim:filetype=lisp
+;; cl-format.ert --- Tests for cl-format  -*- lexical-binding: t; mode: emacs-lisp -*- vim:filetype=lisp
 ;;*****************************************************************************
 ;;*    Rosenmueller            format.tst                                     *
 ;;*****************************************************************************
@@ -127,55 +127,52 @@
 ")))
 
 
-(labels ((format-blocksatz (stream parts prefix &optional line-length start-p end-p)
-           (if (null stream)
-               (with-output-to-string
-                 (format-blocksatz standard-output parts prefix line-length start-p end-p))
-             (unless (endp parts)
-               (setq line-length (or line-length ;; #|(sys::line-length stream)|#
-                                     72))
-               (when start-p (cl-format stream prefix))
-               (loop do
+(cl-labels ((format-blocksatz (stream parts prefix &optional line-length start-p end-p)
+             (if (null stream)
+                 (with-output-to-string
+                   (format-blocksatz standard-output parts prefix line-length start-p end-p))
+               (unless (cl-endp parts)
+                 (setq line-length (or line-length
+                                       ;; #|(sys::line-length stream)|#
+                                       72))
+                 (when start-p (cl-format stream prefix))
+                 (cl-loop
 ;;; Hier ist parts /= NIL
-                     (let ((pos (current-column))
+                  (let ((pos (current-column))
 ;;; #+CMU lisp::charpos
 ;;; #+SBCL sb-kernel:charpos
 ;;; #+OpenMCL ccl::column
 ;;; #+LISPWORKS stream:stream-line-column
-                           (parts-now '()))
-                       (let ((pos-now pos))
-                         (loop do
-                               (when (endp parts) (return))
-                               (let* ((part (first parts))
-                                      (part-length (length part)))
-                                 (unless (null parts-now)
-                                   (when (> (+ pos-now part-length) line-length)
-                                     (return)
-                                     ) )
-                                 (pop parts)
-                                 (push part parts-now)
-                                 (incf pos-now part-length)
-                                 ) ) )
+                        (parts-now '()))
+                    (let ((pos-now pos))
+                      (cl-loop
+                       (when (cl-endp parts) (cl-return))
+                       (let* ((part (cl-first parts))
+                              (part-length (length part)))
+                         (unless (null parts-now)
+                           (when (> (+ pos-now part-length) line-length)
+                             (cl-return)))
+                         (pop parts)
+                         (push part parts-now)
+                         (cl-incf pos-now part-length))))
 ;;; Hier ist parts-now /= NIL
-                       (apply #'cl-format
-                              stream
-                              (if (and (endp parts) (not end-p))
-                                  (apply 'concatenate 'string
-                                         (make-list (length parts-now) "~a"))
-                                (concatenate 'string
-                                             "~"
-                                             (prin1-to-string (max 0 (- line-length pos)))
-                                             (if (= (length parts-now) 1) "@" "")
-                                             "<"
-                                             (apply #'concatenate 'string
-                                                    "~a"
-                                                    (make-list (1- (length parts-now)) "~;~a")
-                                                    )
-                                             "~>"
-                                             ))
-                              (nreverse parts-now)))
-                     (when (endp parts) (return))
-                     (cl-format stream prefix))))))
+                    (apply #'cl-format
+                           stream
+                           (if (and (cl-endp parts) (not end-p))
+                               (apply 'cl-concatenate 'string
+                                      (make-list (length parts-now) "~a"))
+                             (cl-concatenate 'string
+                                          "~"
+                                          (prin1-to-string (max 0 (- line-length pos)))
+                                          (if (= (length parts-now) 1) "@" "")
+                                          "<"
+                                          (apply #'cl-concatenate 'string
+                                                 "~a"
+                                                 (make-list (1- (length parts-now)) "~;~a"))
+                                          "~>"))
+                           (nreverse parts-now)))
+                  (when (cl-endp parts) (cl-return))
+                  (cl-format stream prefix))))))
        
 
   (ert-deftest format-018 ()
@@ -257,9 +254,9 @@
 
 (ert-deftest format-021 ()
   
-  (flet ((foo (x)
-           (cl-format nil "~6,2f|~6,2,1,'*f|~6,2,,'?f|~6f|~,2f|~f" x x x x
-                      x x)))
+  (cl-flet ((foo (x)
+               (cl-format nil "~6,2f|~6,2,1,'*f|~6,2,,'?f|~6f|~,2f|~f"
+                          x x x x x x)))
 
     (should (equal (foo 3.14159)
 ;;;       "  3.14| 31.42|  3.14|3.1416|3.14|3.141590116672995328"
@@ -335,10 +332,10 @@
 ;; Format E
 
 (ert-deftest format-032 ()
-  (flet ((foo (x)
-           (cl-format nil
-            "~9,2,1,,'*e|~10,3,2,2,'?,,'$e|~9,3,2,-2,'%@e|~9,2e"
-            x x x x)))
+  (cl-flet ((foo (x)
+               (cl-format nil
+                          "~9,2,1,,'*e|~10,3,2,2,'?,,'$e|~9,3,2,-2,'%@e|~9,2e"
+                          x x x x)))
             
     (should (equal (foo 3.14159)
                    "  3.14e+0| 31.42$-01|+.003e+03|  3.14e+0"))
@@ -388,7 +385,7 @@
   (dolist (lm '("least" "most"))
     (dolist (pn '("positive" "negative"))
       (dolist (ty '("float")) ; "long"
-        (let* ((s (concat lm "-" pn "-" ty))
+        (let* ((s (concat "cl-" lm "-" pn "-" ty))
                (v (symbol-value (intern s)))
                (e (cl-format nil "~e" v)))
           (should (eql v (ignore-errors
@@ -459,11 +456,12 @@ Scale factor -5: | 0.000003e+06|"))))
 
 
 (ert-deftest format-048 ()
-  (should (equal (loop for i from 0 to 50
-                       for x = (expt 10.0 i)
-                       for s = (cl-format nil "~g" x)
-                       when (char-equal ?0 (aref s (1+ (position ?\. s))))
-                       collect x)
+  (should (equal (cl-loop
+                  for i from 0 to 50
+                  for x = (expt 10.0 i)
+                  for s = (cl-format nil "~g" x)
+                  when (char-equal ?0 (aref s (1+ (cl-position ?\. s))))
+                  collect x)
                  nil)))
 
 
@@ -496,9 +494,9 @@ Scale factor -5: | 0.000003e+06|"))))
 
 
 (ert-deftest format-055 ()
-  (flet ((foo (x)
-           (cl-format nil "~9,2,1,,'*g|~9,3,2,3,'?,,'$g|~9,3,2,0,'%g|~9,2g"
-                      x x x x)))
+  (cl-flet ((foo (x)
+              (cl-format nil "~9,2,1,,'*g|~9,3,2,3,'?,,'$g|~9,3,2,0,'%g|~9,2g"
+                         x x x x)))
     (should (equal (foo 0.0314159)
                    "  3.14e-2|314.2$-04|0.314e-01|  3.14e-2"))
 
@@ -1239,8 +1237,8 @@ new line and over two tabs-*")))
 
 
 (ert-deftest format-172 ()
-  (flet ((foo (n)
-           (cl-format nil "~@|(~r~) error~:p detected." n)))
+  (cl-flet ((foo (n)
+              (cl-format nil "~@|(~r~) error~:p detected." n)))
     (should (equal (foo 0)
                    "Zero errors detected."))
     (should (equal (foo 1)
@@ -1569,7 +1567,7 @@ def")))
                    (defmethod stream-line-column ((s gray-string-output-stream))
                      (let* ((a (slot-value s 'accumulator))
                             (j (length a))
-                            (i (1+ (or (position ?\n a :from-end t) -1))))
+                            (i (1+ (or (cl-position ?\n a :from-end t) -1))))
                        (string-width a :start i :end j)))
                    (list
                     (let ((stream (make-instance 'gray-string-output-stream)))

--- a/clisp-format.el
+++ b/clisp-format.el
@@ -4,7 +4,8 @@
 
 ;; This could need a some clean up.
 
-(require 'cl)
+(require 'cl-lib)
+(eval-when-compile (require 'gv))
 (require 'cl-format-def)
 
 ;;; Code:
@@ -28,7 +29,7 @@
 
 (defun clisp-format-float-for-e
   (w d e k overflowchar padchar exponentchar plus-sign-flag arg stream)
-  ;; (multiple-value-bind (oldexponent mantissa)
+  ;; (cl-multiple-value-bind (oldexponent mantissa)
   ;;     (float-scale-exponent (abs arg))
   
   (let* ((oldexponent (clisp-float-scale-exponent arg))
@@ -40,7 +41,7 @@
          ;; mantd = number of Mantissa-Digits behind the point
          (mantd (if d (if (> k 0) (1+ (- d k)) d) nil))
          ;; no rounding takes place within the first (+ 1 (abs k)) digits.
-         (dmin (if (minusp k) (- 1 k) nil)) ; hereafter: demand, that
+         (dmin (if (cl-minusp k) (- 1 k) nil)) ; hereafter: demand, that
          ;; mantwidth = number of available characters (or nil)
          ;; for the Mantissa (incl. sign, point)
          (mantwidth (if w (- w 2 expdigitsneed) nil)))
@@ -49,12 +50,12 @@
         ;; if Overflowchar and w and e being stated, Exponent needs more room:
         (clisp-format-padding w overflowchar stream)
       (progn
-        (when (and w (or plus-sign-flag (minusp arg)))
+        (when (and w (or plus-sign-flag (cl-minusp arg)))
           (setq mantwidth (1- mantwidth)))
         ;; mantwidth = number of available characters (or nil)
         ;;  for the Mantissa (without sign,including point)
-        (multiple-value-bind (mantdigits mantdigitslength
-                                         leadingpoint trailingpoint point-pos)
+        (cl-multiple-value-bind (mantdigits mantdigitslength
+                                            leadingpoint trailingpoint point-pos)
             (clisp-format-float-to-string
              (abs arg) mantwidth mantd (- k oldexponent) dmin)
           (when w
@@ -68,10 +69,10 @@
                   (setq mantwidth (- mantwidth 1))
                 (setq leadingpoint nil))))
           ;; mantwidth characters remain.
-          (if (and overflowchar w (minusp mantwidth))
+          (if (and overflowchar w (cl-minusp mantwidth))
               (clisp-format-padding w overflowchar stream) ; not enough room -> overflow
             (progn
-              (when (and (plusp k) (< k point-pos))
+              (when (and (cl-plusp k) (< k point-pos))
                 ;; format-float-to-string rounded the mantissa up above 1
                 ;; so that all our assumptions are now wrong and we are
                 ;; about to get (clisp-format nil "~8e" .999999d9) => " 10.0d+8"
@@ -81,21 +82,21 @@
                         (format "%s" (abs new-exponent))))
                   ;; shift the decimal point left
                   (dotimes (i shift)
-                    (rotatef (aref mantdigits (- point-pos i))
+                    (cl-rotatef (aref mantdigits (- point-pos i))
                              (aref mantdigits (- point-pos i 1))))
                   ;; update for the the exponent change
                   (when mantwidth
-                    (incf mantwidth (- (length expdigits)
+                    (cl-incf mantwidth (- (length expdigits)
                                        (length new-expdigits))))
                   (setq exponent new-exponent
                         expdigits new-expdigits)
                   ;; update for the trailing point change
                   (when trailingpoint
                     (setq trailingpoint nil)
-                    (when mantwidth (incf mantwidth)))))
+                    (when mantwidth (cl-incf mantwidth)))))
               (when (and w (> mantwidth 0))
                 (clisp-format-padding mantwidth padchar stream))
-              (if (minusp arg)
+              (if (cl-minusp arg)
                   (write-char ?- stream)
                 (if plus-sign-flag (write-char ?+ stream)))
               (when leadingpoint (write-char ?0 stream))
@@ -104,16 +105,16 @@
               (write-char
                (or exponentchar ?e)
                stream)
-              (write-char (if (minusp exponent) ?- ?+) stream)
+              (write-char (if (cl-minusp exponent) ?- ?+) stream)
               (when (and e (> e (length expdigits)))
                 (clisp-format-padding (- e (length expdigits)) ?0 stream))
               (princ expdigits stream))))))))
 
 (defun clisp-format-float-for-f (w d k overflowchar padchar plus-sign-flag
                                    arg stream)
-  (let ((width (if w (if (or plus-sign-flag (minusp arg)) (1- w) w) nil)))
+  (let ((width (if w (if (or plus-sign-flag (cl-minusp arg)) (1- w) w) nil)))
     ;; width = available characters without sign
-    (multiple-value-bind (digits digitslength leadingpoint trailingpoint)
+    (cl-multiple-value-bind (digits digitslength leadingpoint trailingpoint)
         (clisp-format-float-to-string arg width d k 0)
       (when (eql d 0)
         (setq trailingpoint nil)) ; d=0 -> no additional zero behind
@@ -124,11 +125,11 @@
         (when trailingpoint     ; plan possibly additional zero behind
           (if (> width 0) (setq width (1- width)) (setq trailingpoint nil))))
       ;; width characters still remain.
-      (if (and overflowchar w (minusp width))
+      (if (and overflowchar w (cl-minusp width))
           (clisp-format-padding w overflowchar stream) ; not enough room -> overflow
         (progn
           (when (and w (> width 0)) (clisp-format-padding width padchar stream))
-          (if (minusp arg)
+          (if (cl-minusp arg)
               (write-char ?- stream)
             (if plus-sign-flag (write-char ?+ stream)))
           (when leadingpoint (write-char ?0 stream))
@@ -146,75 +147,75 @@
                              stream)
   (let* ((clisp-format-print-base base))
     (if (and (zerop mincol) (not commaflag) (not positive-sign-flag))
-        (clisp-princ-with-base arg stream)        ; normal output does the job
+        (clisp-princ-with-base arg stream) ; normal output does the job
       (let* ((oldstring (clisp-princ-with-base-to-string arg))
              (oldstring-length (length oldstring))
              (number-of-digits
-              (if (minusp arg) (1- oldstring-length) oldstring-length) )
+              (if (cl-minusp arg) (1- oldstring-length) oldstring-length) )
              (number-of-commas
               (if commaflag (floor (1- number-of-digits) commainterval) 0) )
              (positive-sign (and positive-sign-flag (>= arg 0)))
              (newstring-length
-              (+ (if positive-sign 1 0) ; sign
+              (+ (if positive-sign 1 0)              ; sign
                  oldstring-length number-of-commas)) ; digits, commas
              (newstring (make-string newstring-length 32)) )
         ;; first the sign +:
         (when positive-sign (setf (aref newstring 0) ?+))
         ;; Then convert oldstring in newstring, skipping the commas:
         (let ((oldpos oldstring-length) (newpos newstring-length))
-          (loop do
-                (decf oldpos)
-                (when (minusp oldpos) (return))
-                (decf newpos)
-                (setf (aref newstring newpos) (aref oldstring oldpos))
-                (when (and (plusp number-of-commas) ; insert a comma?
-                           (zerop (mod (- oldstring-length oldpos) commainterval)))
-                  (decf newpos)
-                  (setf (aref newstring newpos) commachar)
-                  (decf number-of-commas))))
+          (cl-loop
+           (cl-decf oldpos)
+           (when (cl-minusp oldpos) (cl-return))
+           (cl-decf newpos)
+           (setf (aref newstring newpos) (aref oldstring oldpos))
+           (when (and (cl-plusp number-of-commas) ; insert a comma?
+                      (zerop (mod (- oldstring-length oldpos) commainterval)))
+             (cl-decf newpos)
+             (setf (aref newstring newpos) commachar)
+             (cl-decf number-of-commas))))
         (if (zerop mincol)
-            (princ newstring stream) ; faster
+            (princ newstring stream)    ; faster
           (clisp-format-padded-string mincol 1 0 padchar t newstring stream))))))
 
 
-(defun* clisp-format-do-format-justification (stream colon-modifier atsign-modifier
-                                                     mincol colinc minpad padchar
-                                                     pos check-on-line-overflow firstpiece
-                                                     supplementary-need line-length piecelist) ; ABI
+(cl-defun clisp-format-do-format-justification (stream colon-modifier atsign-modifier
+                                                       mincol colinc minpad padchar
+                                                       pos check-on-line-overflow firstpiece
+                                                       supplementary-need line-length piecelist) ; ABI
   (if (null mincol) (setq mincol 0))
   (if (null colinc) (setq colinc 1))
   (if (null minpad) (setq minpad 0))
   (if (null padchar) (setq padchar ?\s))
   (if piecelist
-      (multiple-value-bind (padblocklengths width)
+      (cl-multiple-value-bind (padblocklengths width)
           (clisp-format-justified-segments
            mincol colinc minpad
            colon-modifier atsign-modifier piecelist)
         (when (and check-on-line-overflow
                    (> (+ (or pos 0) width (or supplementary-need 0))
-                      (or line-length ;(sys::line-length stream)
+                      (or line-length   ;(sys::line-length stream)
                           72)))
           (princ firstpiece stream))
-        (do ((i 0 (1+ i)))
+        (cl-do ((i 0 (1+ i)))
             (nil)
           (when (aref padblocklengths i)
             (clisp-format-padding (aref padblocklengths i) padchar stream))
-          (when (null piecelist) (return))
+          (when (null piecelist) (cl-return))
           (princ (pop piecelist) stream)))
     (clisp-format-padding mincol padchar stream)))
 
 (defun clisp-format-justified-segments
-  (mincol colinc minpad justify-left justify-right piecelist)
+    (mincol colinc minpad justify-left justify-right piecelist)
   (declare (fixnum mincol colinc minpad))
   (let ((piecesnumber 0)
         (pieceswidth 0))
     (dolist (piece piecelist)
       (declare (simple-string piece))
-      (incf piecesnumber)
-      (incf pieceswidth (string-width piece)))
+      (cl-incf piecesnumber)
+      (cl-incf pieceswidth (string-width piece)))
     (let* ((new-justify-left
             (or justify-left (and (= piecesnumber 1) (not justify-right))))
-           (padblocks (+ piecesnumber -1       ; number of insertion-points
+           (padblocks (+ piecesnumber -1 ; number of insertion-points
                          (if new-justify-left 1 0) (if justify-right 1 0)))
            (width-need (+ pieceswidth (* padblocks minpad)))
            (width (+ mincol
@@ -222,8 +223,8 @@
                          0
                        (* (ceiling (- width-need mincol) colinc) colinc)))))
       (declare (fixnum piecesnumber pieceswidth padblocks width-need width))
-      (multiple-value-bind (padwidth rest)
-          (values 
+      (cl-multiple-value-bind (padwidth rest)
+          (cl-values 
            (floor (- width pieceswidth) padblocks)
            (mod (- width pieceswidth)
                 padblocks)) 
@@ -232,12 +233,12 @@
           (unless new-justify-left (setf (aref padblock-lengths 0) nil))
           (unless justify-right
             (setf (aref padblock-lengths piecesnumber) nil))
-          (do ((i 0 (1+ i)))
+          (cl-do ((i 0 (1+ i)))
               ((zerop rest))
             (when (aref padblock-lengths i)
-              (incf (aref padblock-lengths i))
-              (decf rest)))
-          (values padblock-lengths width))))))
+              (cl-incf (aref padblock-lengths i))
+              (cl-decf rest)))
+          (cl-values padblock-lengths width))))))
 
 
 
@@ -246,24 +247,26 @@
   (unless (and (<= 1 arg) (<= arg 3999))
     (cl-format-eval-error
      "Argument out of range" '(and (<= 1 arg) (<= arg 3999))))
-  (do ((charlistr       '(?M ?D ?C ?L ?X ?V ?I) (cdr charlistr))
-       (valuelistr     '(1000 500 100 50  10   5   1 ) (cdr valuelistr))
-       (lowercharlistr  '(?C ?C ?X ?X ?I ?I    ) (cdr lowercharlistr))
-       (lowervaluelistr '(100 100 10  10   1   1   0 ) (cdr lowervaluelistr))
-       (value arg
-              (multiple-value-bind (multiplicity restvalue)
-                  (values 
-                   (floor value (first valuelistr))
-                   (mod value
-                        (first valuelistr))) 
-                (dotimes (i multiplicity) (write-char (first charlistr) stream))
-                (let ((loweredvalue (- (first valuelistr) (first lowervaluelistr))))
-                  (if (>= restvalue loweredvalue)
-                      (progn
-                        (write-char (first lowercharlistr) stream)
-                        (write-char (first charlistr) stream)
-                        (- restvalue loweredvalue))
-                    restvalue)))))
+  (cl-do ((charlistr       '(?M ?D ?C ?L ?X ?V ?I) (cdr charlistr))
+          (valuelistr     '(1000 500 100 50  10   5   1 ) (cdr valuelistr))
+          (lowercharlistr  '(?C ?C ?X ?X ?I ?I    ) (cdr lowercharlistr))
+          (lowervaluelistr '(100 100 10  10   1   1   0 ) (cdr lowervaluelistr))
+          (value arg
+                 (cl-multiple-value-bind (multiplicity restvalue)
+                     (cl-values 
+                      (floor value (cl-first valuelistr))
+                      (mod value
+                           (cl-first valuelistr))) 
+                   (dotimes (i multiplicity) (write-char (cl-first charlistr)
+                                                         stream))
+                   (let ((loweredvalue (- (cl-first valuelistr)
+                                          (cl-first lowervaluelistr))))
+                     (if (>= restvalue loweredvalue)
+                         (progn
+                           (write-char (cl-first lowercharlistr) stream)
+                           (write-char (cl-first charlistr) stream)
+                           (- restvalue loweredvalue))
+                       restvalue)))))
       ((zerop value))))
 
 (defun clisp-format-old-roman (arg stream)
@@ -271,16 +274,16 @@
   (unless (and (<= 1 arg) (<= arg 4999))
     (cl-format-eval-error
      "Argument out of range" '(and (<= 1 arg) (<= arg 4999))))
-  (do ((charlistr  '(?M  ?D ?C ?L ?X ?V ?I) (cdr charlistr))
-       (valuelistr '(1000 500 100 50  10   5   1) (cdr valuelistr))
-       (value arg (multiple-value-bind (multiplicity restvalue)
-                      (values 
-                       (floor value (first valuelistr))
-                       (mod value
-                            (first valuelistr))) 
-                    (dotimes (i multiplicity)
-                      (write-char (first charlistr) stream))
-                    restvalue)))
+  (cl-do ((charlistr  '(?M  ?D ?C ?L ?X ?V ?I) (cdr charlistr))
+          (valuelistr '(1000 500 100 50  10   5   1) (cdr valuelistr))
+          (value arg (cl-multiple-value-bind (multiplicity restvalue)
+                         (cl-values 
+                          (floor value (cl-first valuelistr))
+                          (mod value
+                               (cl-first valuelistr))) 
+                       (dotimes (i multiplicity)
+                         (write-char (cl-first charlistr) stream))
+                       restvalue)))
       ((zerop value))))
 
 
@@ -302,15 +305,15 @@
   (if (zerop arg)
       (princ "zeroth" stream)
     (progn
-      (when (minusp arg) (princ "minus " stream) (setq arg (- arg)))
-      (multiple-value-bind (hundreds tens-and-ones)
-          (values (floor arg 100)
-                  (mod arg 100))
+      (when (cl-minusp arg) (princ "minus " stream) (setq arg (- arg)))
+      (cl-multiple-value-bind (hundreds tens-and-ones)
+          (cl-values (floor arg 100)
+                     (mod arg 100))
         (when (> hundreds 0) (clisp-format-cardinal (* hundreds 100) stream))
         (if (zerop tens-and-ones)
             (princ "th" stream)
-          (multiple-value-bind (tens ones) (values (floor tens-and-ones 10)
-                                                   (mod tens-and-ones 10)) 
+          (cl-multiple-value-bind (tens ones) (cl-values (floor tens-and-ones 10)
+                                                         (mod tens-and-ones 10)) 
             (when (> hundreds 0) (write-char ?\s stream))
             (cond ((< tens 2)
                    (princ (aref clisp-format-ordinal-ones tens-and-ones) stream))
@@ -330,23 +333,23 @@
   (if (zerop arg)
       (princ "zero" stream)
     (progn
-      (when (minusp arg) (princ "minus " stream) (setq arg (- arg)))
-      (labels ((blocks1000 (illions-list arg) ; decomposition in 1000er-Blocks
-                 (when (null illions-list)
-                   (cl-format-eval-error "The argument too large" arg))
-                 (multiple-value-bind (thousands small)
-                     (values (truncate arg 1000)
-                             (- arg
-                                (* 1000
-                                   (truncate arg
-                                             1000)))) 
-                   (when (> thousands 0)
-                     (blocks1000 (cdr illions-list) thousands))
-                   (when (> small 0)
-                     (when (> thousands 0)
-                       (princ ", " stream))
-                     (clisp-format-small-cardinal small stream)
-                     (princ (car illions-list) stream)))))
+      (when (cl-minusp arg) (princ "minus " stream) (setq arg (- arg)))
+      (cl-labels ((blocks1000 (illions-list arg) ; decomposition in 1000er-Blocks
+                    (when (null illions-list)
+                      (cl-format-eval-error "The argument too large" arg))
+                    (cl-multiple-value-bind (thousands small)
+                        (cl-values (truncate arg 1000)
+                                   (- arg
+                                      (* 1000
+                                         (truncate arg
+                                                   1000)))) 
+                      (when (> thousands 0)
+                        (blocks1000 (cdr illions-list) thousands))
+                      (when (> small 0)
+                        (when (> thousands 0)
+                          (princ ", " stream))
+                        (clisp-format-small-cardinal small stream)
+                        (princ (car illions-list) stream)))))
         (blocks1000
                                         ; American (billion=10^9)
          '("" " thousand" " million" " billion" " trillion" " quadrillion"
@@ -358,8 +361,8 @@
          arg)))))
 
 (defun clisp-format-small-cardinal (arg stream)
-  (multiple-value-bind (hundreds tens-and-ones)
-      (values
+  (cl-multiple-value-bind (hundreds tens-and-ones)
+      (cl-values
        (truncate arg 100)
        (- arg
           (* 100
@@ -369,12 +372,12 @@
       (princ " hundred" stream))
     (when (> tens-and-ones 0)
       (when (> hundreds 0) (princ " and " stream))
-      (multiple-value-bind (tens ones)
-          (values (truncate tens-and-ones 10)
-                  (- tens-and-ones
-                     (* 10
-                        (truncate tens-and-ones
-                                  10)))) 
+      (cl-multiple-value-bind (tens ones)
+          (cl-values (truncate tens-and-ones 10)
+                     (- tens-and-ones
+                        (* 10
+                           (truncate tens-and-ones
+                                     10)))) 
         (if (< tens 2)
             (princ
              (aref clisp-format-cardinal-ones tens-and-ones) stream)
@@ -414,7 +417,7 @@
                (when (and (stringp object)
                           (> (length object) 0)
                           (eq ?+ (aref object 0)))
-                 (decf numstart)
+                 (cl-decf numstart)
                  (aset number numstart ?+))
                (downcase (substring number numstart))))
             (t object))
@@ -436,7 +439,7 @@
           (list (buffer-string)
                 (1- (point-max))
                 nil nil nil t)
-        (incf scale (clisp-format-float-to-string--expand-exponent))
+        (cl-incf scale (clisp-format-float-to-string--expand-exponent))
         (goto-char 1)
         (let (dot-pos)
           (if (search-forward "." nil t)
@@ -515,7 +518,51 @@
         (delete-region (1- (point)) (point-max)))
     0))
 
-(defsetf char-after (&optional pos) (char)
+(eval-when-compile
+  (defmacro cl-defsetf (name arg1 &rest args)
+    "Define a `setf' method.
+This macro is an easy-to-use substitute for `define-setf-expander'
+that works well for simple place forms.
+
+In the simple `defsetf' form, `setf's of the form (setf (NAME
+ARGS...) VAL) are transformed to function or macro calls of the
+form (FUNC ARGS... VAL).  For example:
+
+  (defsetf aref aset)
+
+You can replace this form with `gv-define-simple-setter'.
+
+Alternate form: (defsetf NAME ARGLIST (STORE) BODY...).
+
+Here, the above `setf' call is expanded by binding the argument
+forms ARGS according to ARGLIST, binding the value form VAL to
+STORE, then executing BODY, which must return a Lisp form that
+does the necessary `setf' operation.  Actually, ARGLIST and STORE
+may be bound to temporary variables which are introduced
+automatically to preserve proper execution order of the arguments.
+For example:
+
+  (defsetf nth (n x) (v) \\=`(setcar (nthcdr ,n ,x) ,v))
+
+You can replace this form with `gv-define-setter'.
+
+\(fn NAME [FUNC | ARGLIST (STORE) BODY...])"
+    (declare (debug
+              (&define name
+                       [&or [symbolp &optional stringp]
+                            [cl-lambda-list (symbolp)]]
+                       cl-declarations-or-string def-body)))
+    (if (and (listp arg1) (consp args))
+        ;; Like `gv-define-setter' but with `cl-function'.
+        `(gv-define-expander ,name
+           (lambda (do &rest args)
+             (gv--defsetter ',name
+                            (cl-function
+                             (lambda (,@(car args) ,@arg1) ,@(cdr args)))
+			    do args)))
+      `(gv-define-simple-setter ,name ,arg1 ,(car args)))))
+
+(cl-defsetf char-after (&optional pos) (char)
   `(save-excursion
      (let ((char ,char)
            (pos ,pos))
@@ -524,7 +571,7 @@
        (insert char)
        char)))
 
-(defsetf char-before (&optional pos) (char)
+(cl-defsetf char-before (&optional pos) (char)
   `(setf (char-after (1- ,pos)) ,char))
 
 (defun clisp-format-float-to-string--round (digits dot-pos)
@@ -539,16 +586,16 @@
           (when (>= digit ?5)
             (when (= ?. (char-after))
               (backward-char))
-            (setq digit (incf (char-after)))
+            (setq digit (cl-incf (char-after)))
             (while (and (not (bobp))
                         (= digit (1+ ?9)))
-              (decf (char-after) 10)
+              (cl-decf (char-after) 10)
               (backward-char)
               (when (= ?. (char-after))
                 (backward-char))
-              (setq digit (incf (char-after))))
+              (setq digit (cl-incf (char-after))))
             (when (= digit (1+ ?9))
-              (decf (char-after) 10)
+              (cl-decf (char-after) 10)
               (insert ?1)))))
     (if (> digits 0)
         (progn


### PR DESCRIPTION
I had to switch tests to lexical-binding to make tests pass (to make them run, actually).  lexical-binding has become a de facto standard in Elisp and it always has been in CL.

I did not switch it in other files, however.

`cl-defsetf`, unlike other macros and functions, is not provided in `cl-lib`; to minimize changes to existing code, I defined `cl-defsetf` in the file, definition taken verbatim from Emacs 27.  It is not exported (only defined at compile time).  It is now recommended to use `gv-` macros instead.

I changed some `flet` forms to `labels` forms; some of their local functions reference the others.  In `flet` they were erroneously visible; not so in `cl-flet`.

Removed `do` from trivial `loop` forms.

Tests do pass and compiler does not emit warnings.  But there still might be issues.  If such get reported in near future, I'll respond.